### PR TITLE
fix: remove auth endpoint in options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: 'The endpoint to send a POST request to once files are uploaded.'
     required: false
     default: ''
-  auth-endpoint:
-    description: 'The authentication endpoint to send endpoint client ID and secret to gain the bearer token.'
-    required: false
-    default: ''
   endpoint-user-agent:
     description: 'The User-Agent string for every request to the endpoint.'
     required: false

--- a/src/classes/Endpoint.ts
+++ b/src/classes/Endpoint.ts
@@ -34,10 +34,7 @@ export default class Endpoint {
 
 export interface EndpointOptions {
     url: string
-    authUrl: string
-    
     token: string
-
     userAgent: string
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ import { setOutput } from '@actions/core'
         version: versions[0].version
     }
 
-    if (options.endpoint && option.endpointUA && options.endpointToken) {
+    if (options.endpoint && options.endpointUA && options.endpointToken) {
         debugLog('Enough API options are supplied')
 
         const endpoint = new Endpoint({

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,12 +77,11 @@ import { setOutput } from '@actions/core'
         version: versions[0].version
     }
 
-    if (options.endpoint && options.authEndpoint && options.endpointToken) {
+    if (options.endpoint && option.endpointUA && options.endpointToken) {
         debugLog('Enough API options are supplied')
 
         const endpoint = new Endpoint({
             url: options.endpoint,
-            authUrl: options.authEndpoint,
             token: options.endpointToken,
             userAgent: options.endpointUA
         })

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,11 +35,7 @@ export function getOptions() {
         // Endpoint Configuration
 
         endpoint: getInput('endpoint'),
-        authEndpoint: getInput('auth-endpoint'),
         endpointUA: getInput('endpoint-user-agent'),
-
-        // Endpoint Authorization
-
         endpointToken: getInput('endpoint-token'),
 
         // CDN Authorization


### PR DESCRIPTION
No longer used or needed, `endpoint-token` fulfills the needs.